### PR TITLE
getPatientSet

### DIFF
--- a/R/getPatientSets.R
+++ b/R/getPatientSets.R
@@ -1,0 +1,35 @@
+# Copyright 2014, 2015 The Hyve B.V.
+# Copyright 2014 Janssen Research & Development, LLC.
+#
+# This file is part of tranSMART R Client: R package allowing access to
+# tranSMART's data via its RESTful API.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the following terms:
+#
+#   1. You may convey a work based on this program in accordance with
+#      section 5, provided that you retain the above notices.
+#   2. You may convey verbatim copies of this program code as you receive
+#      it, in any medium, provided that you retain the above notices.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>..
+
+getPatientSet <- function(id) {
+    if (!is.numeric(id) || id %% 1 != 0 || id < 0) {
+        stop(paste(id, "is not a valid positive integer"))
+    }
+    .ensureTransmartConnection()
+
+    patientSet <- .transmartGetJSON(paste("/patient_sets/", id, sep=''))
+    names(patientSet$patients) <- sapply(patientSet$patients, function(p) {p$inTrialId})
+
+    patientSet
+}

--- a/R/getPatientSets.R
+++ b/R/getPatientSets.R
@@ -29,7 +29,14 @@ getPatientSet <- function(id) {
     .ensureTransmartConnection()
 
     patientSet <- .transmartGetJSON(paste("/patient_sets/", id, sep=''))
-    names(patientSet$patients) <- sapply(patientSet$patients, function(p) {p$inTrialId})
 
+    # Don't expose id, it should not be used and will be removed from a future version of rest-api
+    if (length(patientSet$patients) && "id" %in% names(patientSet$patients[[1]])) {
+        for (i in seq_along(patientSet$patients)) {
+            patientSet$patients[[i]]$id <- NULL
+        }
+    }
+
+    names(patientSet$patients) <- sapply(patientSet$patients, function(p) {p$inTrialId})
     patientSet
 }

--- a/R/getSubjects.R
+++ b/R/getSubjects.R
@@ -28,8 +28,8 @@ getSubjects <- function(study.name, as.data.frame = TRUE) {
     serverResult <- .transmartGetJSON(paste("/studies/", study.name,"/subjects", sep=""))
     listOfSubjects <- serverResult$subjects
 
-    subjectIDs <- sapply(listOfSubjects, FUN = function(x) { x[["id"]] })
-    names(listOfSubjects) <- paste("id",subjectIDs,sep="")
+    subjectIDs <- sapply(listOfSubjects, FUN = function(x) { x$inTrialId })
+    names(listOfSubjects) <- subjectIDs
 
     if (as.data.frame) return(.listToDataFrame(listOfSubjects))
     listOfSubjects

--- a/man/getPatientSet.Rd
+++ b/man/getPatientSet.Rd
@@ -1,0 +1,35 @@
+\name{getPatientSet}
+\alias{getPatientSet}
+\title{
+  Download a patient set by id.
+}
+\description{
+  This function retrieves information about a patient set, including the patients in that set.
+}
+\usage{
+getPatientSet(id)
+}
+
+\arguments{
+  \item{id}{an integral number, the id of the patient set}
+\details{
+  The function will return a named list with properties of the patient set. Patient sets are created in the Transmart web interface or with the \code{\link{getPatientSetId}} call (still to be implemented). Currently there is no support in the legacy Transmart web interface to view the id of a patient set, but the new web app will support that.
+}
+}
+\value{
+  A named list with properties of the patient set. The \code{patients} element contains a list of patients.
+}
+\references{}
+\author{Jan Kanis. 
+Contact: development@thehyve.nl}
+\note{To be able to access a transmart database, you need to be connected to the server the database is on. If you haven't connected to the server yet, establish a connection using the \code{\link{connectToTransmart}} function.}
+\seealso{\code{\link{getSubjects}}}
+\examples{
+\dontrun{
+    # The following will retrieve information on the patient set with id 28714
+    getPatientSet(28714)
+    }
+}
+
+\keyword{ database }
+\keyword{ transmart }


### PR DESCRIPTION
implement getPatientSet in the R client. This function requires the update to transmart in branch QueryResult_render.

There is also a change in getSubjects to not expose the database id. The change is backward compatible on the R side since the database id was not useful anyway.
