### PR TITLE
Switch to jsonlite instead of rjson

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: R Client for accessing the tranSMART RESTful API
 Version: 0.3.2
 Date: 2016-07-18
-Depends: httr, rjson, plyr, RProtoBuf, hash, reshape
+Depends: httr, jsonlite, plyr, RProtoBuf, hash, reshape
 Author: Tim Dorscheidt, Jan Kanis, Rianne Jansen
 Maintainer: <support@thehyve.nl>
 Description: This package exposes tranSMART's RESTful API as a set of R functions. It uses tranSMART's OAuth authentication to access the data for which the user is authorized, and allows exploring and downloading the data.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -21,12 +21,13 @@ apply:
 | ---------- | -------- | -----------------------------------------------------------
 | Protobuf   | BSD      | <http://grails.org/License>
 | httr       | MIT      | <http://cran.r-project.org/web/packages/httr/index.html>
-| rjson      | GPL2     | <http://cran.r-project.org/web/packages/rjson/index.html>
-| RProtoBuf  | GPL2     | <http://cran.r-project.org/web/packages/RProtoBuf/index.html>
+| jsonlite   | MIT      | <http://cran.r-project.org/web/packages/jsonlite/index.html>
+| RProtoBuf  | GPL2+    | <http://cran.r-project.org/web/packages/RProtoBuf/index.html>
 | plyr       | MIT      | <http://cran.r-project.org/web/packages/plyr/index.html>
-| hash       | GPL3     | <http://cran.r-project.org/web/packages/hash/index.html>
-| bitopts    | GPL3     | <http://cran.r-project.org/web/packages/bitops/index.html>
-| RCpp       | GPL2     | <http://cran.r-project.org/web/packages/Rcpp/index.html>
+| hash       | GPL2+    | <http://cran.r-project.org/web/packages/hash/index.html>
+| reshape    | MIT      | <http://cran.r-project.org/web/packages/reshape/>
+| bitopts    | GPL2+    | <http://cran.r-project.org/web/packages/bitops/index.html>
+| RCpp       | GPL2+    | <http://cran.r-project.org/web/packages/Rcpp/index.html>
 | R overall  | Multiple | <http://www.r-project.org/Licenses/>
 
 This program is free software: you can redistribute it and/or modify it under

--- a/R/RClientConnectionManager.R
+++ b/R/RClientConnectionManager.R
@@ -265,6 +265,11 @@ function (oauthDomain = transmartClientEnv$transmartDomain, prefetched.request.t
     return('unknown')
 }
 
+# Wrap this in case we need to change json libraries again
+.fromJSON <- function(json) {
+	fromJSON(json, simplifyDataFrame=F, simplifyMatrix=F)
+}
+
 .serverMessageExchange <- 
 function(apiCall, httpHeaderFields, accept.type = "default", post.body = NULL, show.progress = (accept.type == 'binary') ) {
     if (any(accept.type == c("default", "hal"))) {
@@ -294,11 +299,11 @@ function(apiCall, httpHeaderFields, accept.type = "default", post.body = NULL, s
         result$statusMessage <- http_status(req)$message
     	switch(.contentType(result$headers),
                json = {
-                   result$content <- fromJSON(result$content)
+                   result$content <- .fromJSON(result$content)
                    result$JSON <- TRUE
                },
                hal = {
-                   result$content <- .simplifyHalList(fromJSON(result$content))
+                   result$content <- .simplifyHalList(.fromJSON(result$content))
                    result$JSON <- TRUE
                })
         return(result)

--- a/R/getHighdimData.R
+++ b/R/getHighdimData.R
@@ -133,8 +133,9 @@ getHighdimData <- function(study.name, concept.match = NULL, concept.link = NULL
 
 # The argument is a single named list
 .expandConstraints <- function(constraints) {
-    # The JSON encoder encodes single item vectors as scalars. We need those to be lists as well sometimes.
-    j <- function(val) if (length(val) == 1) list(val) else val
+    # Previously used json packages encode length 1 vectors as scalars, we need them as lists. Jsonlite which we are using
+    # now doesn't do that so this wrapping function is now a no-op.
+    j <- function(val) val
     
     # some deep functional/lazy magic
     mapply(function(val, con) switch(con,

--- a/bin/installCommands.R
+++ b/bin/installCommands.R
@@ -25,9 +25,9 @@
 
 # Notes for first time installers:
 
-# The package transmartRClient depends on five packages: httr, rjson, RProtoBuf, plyr, hash, and reshape.
+# The package transmartRClient depends on these packages: httr, jsonlite, RProtoBuf, plyr, hash, and reshape.
 # You can install them as follows:
-install.packages(pkgs=c("httr", "rjson", "RProtoBuf", "plyr", "hash", "reshape"))
+install.packages(pkgs=c("httr", "jsonlite", "RProtoBuf", "plyr", "hash", "reshape"))
 
 # RProtoBuf depends on the system protobuf headers. For Ubuntu you will need to
 # install the libprotoc-dev and libprotobuf-dev packages.


### PR DESCRIPTION
httr depends on jsonlite, so we are already depending on it transitively.
Removing the rjson dependency is thus a strict decrease in dependencies.
Additionally jsonlite is seen as the best json module for R on the internetz
at this time.
