### PR TITLE
Adapt RInterface to use /v1 prefix when needed.

### DIFF
--- a/R/getHighdimData.R
+++ b/R/getHighdimData.R
@@ -251,7 +251,7 @@ highdimInfo <- function(study.name = NULL, concept.match = NULL, concept.link = 
     .ensureTransmartConnection()
     concept.link <- .getConceptLink(study.name, concept.match, concept.link)
 
-    serverResult <- .transmartGetJSON(paste(concept.link, "/highdim", sep=""))
+    serverResult <- .transmartGetJSON(paste(concept.link, "/highdim", sep=""), noPrefix = TRUE)
     if (length(serverResult$dataTypes) == 0) {
         stop("This high dimensional concept contains no data.")
     }

--- a/man/connectToTransmart.Rd
+++ b/man/connectToTransmart.Rd
@@ -9,13 +9,14 @@
   tranSMART database.
 }
 \usage{
-connectToTransmart(transmartDomain, use.authentication = TRUE, token = NULL, ...)
+connectToTransmart(transmartDomain, use.authentication = TRUE, token = NULL, apiPrefix = NULL, ...)
 }
 
 \arguments{
   \item{transmartDomain}{a character string naming the domain of the tranSMART server to connect to.}
   \item{use.authentication}{logical indicating whether or not to use OAuth authentication. Must be TRUE (default setting) if the tranSMART server requires OAuth authentication}
   \item{token}{A token that can be used to authenticate to Transmart. This is  the "refresh token" in OAuth terminology. To get such a token, use \code{\link{getTransmartToken}} after authenticating interactively for the first time.}
+  \item{apiPrefix}{Prefix for API calls on the tranSMART server. E.g., '/v1' for instances that serve the API endpoints under '/v1' ('/v1/studies' for instance). If not provided, the R client will try to discover based on (the existence of) the '/versions/v1' endpoint.}
   \item{\dots}{additional arguments to be passed on to \code{\link{authenticateWithTransmart}}}
 }
 \details{


### PR DESCRIPTION
Adapt the connection code to determine if a `v1` prefix should be prepended to API calls.
It does so by:
- first checking if a `apiPrefix` parameter is provided;
- if not, trying if a `/versions/v1` endpoint  exists. If so, the `prefix` value from there is used.